### PR TITLE
Command at the end

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    egg (0.4.0)
+    egg (0.4.1)
       thor (~> 0.19.4)
 
 GEM

--- a/lib/egg/dockerfile/ruby.rb
+++ b/lib/egg/dockerfile/ruby.rb
@@ -29,7 +29,8 @@ module Egg
           [:add, "Gemfile* $APP_HOME/"],
           [:env, "BUNDLE_GEMFILE=$APP_HOME/Gemfile BUNDLE_JOBS=4 BUNDLE_WITHOUT=production:staging"],
           [:run, "bundle install"],
-          [:add, ". $APP_HOME"]
+          [:add, ". $APP_HOME"],
+          [:cmd, "<%= command %>"]
         ]
       end
     end

--- a/lib/egg/version.rb
+++ b/lib/egg/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Egg
-  VERSION = "0.4.0".freeze
+  VERSION = "0.4.1".freeze
 end

--- a/spec/lib/dockerfile/node_js_spec.rb
+++ b/spec/lib/dockerfile/node_js_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe Egg::Dockerfile::NodeJS do
 
   it "Can render from a template" do
     df = Egg::Dockerfile.use "NodeJS"
-    df.command = %w[npm start]
+    df.command = "npm start"
     df.node_version = "7.9.0"
     expect(df.render).to match(/FROM node/)
   end
 
   it "Requires setting the nodeJS_version" do
     df = Egg::Dockerfile.use "NodeJS"
-    df.command = ["bin/rails", "server", "-p 3000"]
+    df.command = "npm start"
     expect { df.render }.to raise_error(Egg::Dockerfile::MissingPropertyError)
       .with_message(/node_version/)
   end
@@ -24,5 +24,12 @@ RSpec.describe Egg::Dockerfile::NodeJS do
     df.node_version = "2.4.0"
     expect { df.render }.to raise_error(Egg::Dockerfile::MissingPropertyError)
       .with_message(/command/)
+  end
+
+  it "Renders the command at the end" do
+    df = Egg::Dockerfile.use "NodeJS"
+    df.command = "npm start"
+    df.node_version = "7.9.0"
+    expect(df.render).to match(/CMD npm start$/)
   end
 end

--- a/spec/lib/dockerfile/ruby_spec.rb
+++ b/spec/lib/dockerfile/ruby_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe Egg::Dockerfile::Ruby do
 
   it "Can render from a template" do
     df = Egg::Dockerfile.use "Ruby"
-    df.command = ["bin/rails", "server", "-p 3000"]
+    df.command = "bin/rails server -p 3000"
     df.ruby_version = "2.4.0"
     expect(df.render).to match(/FROM ruby/)
   end
 
   it "Requires setting the ruby_version" do
     df = Egg::Dockerfile.use "Ruby"
-    df.command = ["bin/rails", "server", "-p 3000"]
+    df.command = "bin/rails server -p 3000"
     expect { df.render }.to raise_error(Egg::Dockerfile::MissingPropertyError)
       .with_message(/ruby_version/)
   end
@@ -24,5 +24,12 @@ RSpec.describe Egg::Dockerfile::Ruby do
     df.ruby_version = "2.4.0"
     expect { df.render }.to raise_error(Egg::Dockerfile::MissingPropertyError)
       .with_message(/command/)
+  end
+
+  it "Renders the command at the end" do
+    df = Egg::Dockerfile.use "Ruby"
+    df.command = "bin/rails server -p 3000"
+    df.ruby_version = "2.4.0"
+    expect(df.render).to match(%r{CMD bin/rails server -p 3000$})
   end
 end


### PR DESCRIPTION
@hatchloyalty/platform 

I noticed while setting up rule service that the command I specified in the configuration wasn't getting rendered into the dockerfile. 

The command should be rendered in, then overridden in the docker-compose file. That way the container ought to work in isolation, and when included in other apps, no command configuration per egg config will be needed.