### PR TITLE
[feat ] also ignore .env when setting up app

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    egg (0.4.1)
+    egg (0.4.2)
       thor (~> 0.19.4)
 
 GEM
@@ -87,4 +87,4 @@ DEPENDENCIES
   rspec_junit_formatter (~> 0.2.3)
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/lib/egg/version.rb
+++ b/lib/egg/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Egg
-  VERSION = "0.4.1".freeze
+  VERSION = "0.4.2".freeze
 end

--- a/templates/.dockerignore
+++ b/templates/.dockerignore
@@ -5,3 +5,4 @@ tmp
 node_modules
 coverage
 public/system
+.env


### PR DESCRIPTION
@hatchloyalty/platform 

I want to be able to specify a different set of env variables for the container, compose, and local environments. However, the .env overpowers ENV vars set by the other two means.

To allow us to set the .env locally, but not copy it into the container, we must add `.env` to the `.dockerignore` template generated by egg.