### PR TITLE
Copy .env into ENV directives

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    egg (0.4.1)
+    egg (0.4.2)
       thor (~> 0.19.4)
 
 GEM
@@ -87,4 +87,4 @@ DEPENDENCIES
   rspec_junit_formatter (~> 0.2.3)
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    egg (0.4.2)
+    egg (0.5.0)
       thor (~> 0.19.4)
 
 GEM

--- a/lib/egg/dockerfile/base.rb
+++ b/lib/egg/dockerfile/base.rb
@@ -18,10 +18,7 @@ module Egg
           raise(MissingPropertyError, "Must populate #{attr}") if send(attr).nil?
         end
 
-        final_template = template << [:cmd, "<%= command %>"]
-        unrendered_output = final_template.reduce("") do |out, (command, string)|
-          out << command.to_s.upcase << " " << string << "\n"
-        end
+        unrendered_output = compile_unrendered_output
 
         ERB.new(unrendered_output).result(binding)
       end
@@ -30,12 +27,26 @@ module Egg
         template.insert(do_before(before), [:run, command])
       end
 
+      def env(env_hash)
+        env_string = env_hash.reduce("") do |out, (key, value)|
+          out << key.to_s.upcase << '="' << value.to_s << '" '
+        end
+        template << [:env, env_string]
+      end
+
       private
 
       def do_before(before)
         template.index(before) ||
           template.index { |tc| tc[0] == before[0] } ||
           -1
+      end
+
+      def compile_unrendered_output
+        final_template = template << [:cmd, "<%= command %>"]
+        final_template.reduce("") do |out, (command, string)|
+          out << command.to_s.upcase << " " << string << "\n"
+        end
       end
     end
   end

--- a/lib/egg/dockerfile/base.rb
+++ b/lib/egg/dockerfile/base.rb
@@ -18,7 +18,8 @@ module Egg
           raise(MissingPropertyError, "Must populate #{attr}") if send(attr).nil?
         end
 
-        unrendered_output = template.reduce("") do |out, (command, string)|
+        final_template = template << [:cmd, "<%= command %>"]
+        unrendered_output = final_template.reduce("") do |out, (command, string)|
           out << command.to_s.upcase << " " << string << "\n"
         end
 

--- a/lib/egg/dockerfile/node_js.rb
+++ b/lib/egg/dockerfile/node_js.rb
@@ -25,8 +25,7 @@ module Egg
           [:add, "package.json $APP_HOME/"],
           [:add, "yarn.lock $APP_HOME/"],
           [:run, "yarn install"],
-          [:add, ". $APP_HOME"],
-          [:cmd, "<%= command %>"]
+          [:add, ". $APP_HOME"]
         ]
       end
     end

--- a/lib/egg/dockerfile/ruby.rb
+++ b/lib/egg/dockerfile/ruby.rb
@@ -29,8 +29,7 @@ module Egg
           [:add, "Gemfile* $APP_HOME/"],
           [:env, "BUNDLE_GEMFILE=$APP_HOME/Gemfile BUNDLE_JOBS=4 BUNDLE_WITHOUT=production:staging"],
           [:run, "bundle install"],
-          [:add, ". $APP_HOME"],
-          [:cmd, "<%= command %>"]
+          [:add, ". $APP_HOME"]
         ]
       end
     end

--- a/lib/egg/version.rb
+++ b/lib/egg/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Egg
-  VERSION = "0.4.2".freeze
+  VERSION = "0.5.0".freeze
 end

--- a/lib/egg/version.rb
+++ b/lib/egg/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Egg
-  VERSION = "0.4.1".freeze
+  VERSION = "0.4.2".freeze
 end

--- a/spec/lib/dockerfile_spec.rb
+++ b/spec/lib/dockerfile_spec.rb
@@ -30,4 +30,13 @@ RSpec.describe Egg::Dockerfile do
       expect(df.render).to match(/^RUN echo before bundling\nRUN bundle install$/)
     end
   end
+
+  describe "command" do
+    it "Appends the command at the end" do
+      df = Egg::Dockerfile.use("Ruby")
+      df.command = "test"
+      df.ruby_version = "2.3.3"
+      expect(df.render).to match(/CMD test$/)
+    end
+  end
 end

--- a/spec/lib/dockerfile_spec.rb
+++ b/spec/lib/dockerfile_spec.rb
@@ -39,4 +39,22 @@ RSpec.describe Egg::Dockerfile do
       expect(df.render).to match(/CMD test$/)
     end
   end
+
+  describe "#env" do
+    it "Appends a ENV directive" do
+      df = Egg::Dockerfile.use("Ruby")
+      df.command = "test"
+      df.ruby_version = "2.3.3"
+      df.env(FOO: "ENV SET")
+      expect(df.render).to match(/ENV FOO="ENV SET"/)
+    end
+
+    it "May append multiple vars" do
+      df = Egg::Dockerfile.use("Ruby")
+      df.command = "test"
+      df.ruby_version = "2.3.3"
+      df.env(FOO: "ENV SET", bar: "SetAnother123")
+      expect(df.render).to match(/ENV FOO="ENV SET" BAR="SetAnother123"/)
+    end
+  end
 end

--- a/templates/.dockerignore
+++ b/templates/.dockerignore
@@ -5,3 +5,4 @@ tmp
 node_modules
 coverage
 public/system
+.env

--- a/templates/egg_config.rb
+++ b/templates/egg_config.rb
@@ -8,6 +8,7 @@ Egg::Configuration.new do |config|
   # self.dockerfile = Dockerfile.use "Ruby"
   # self.dockerfile.ruby_version = "2.4.0"
   # self.dockerfile.command = "bin/rails server -p 3000"
+  # self.dockerfile.env(dotenv.env)
 
   # Example docker_compose config:
   # app = config.docker_compose.service "app"


### PR DESCRIPTION
@hatchloyalty/platform 

We have three environments that are in ways configured by environment variables.
* Local, Circle, depends on dotenv `.env` file.
* Docker Container, depends on `ENV` directives in Dockerfiles
* Docker Compose, depends on `env:` configuration in docker-compose.yml, which overwrites ENV in the Dockerfile.

If the `.env` file is present in the container, it overrides all environment configuration, so we must first ignore it in docker environments by adding it to the `dockerignore` file, preventing it from being added to the filesystem by the `ADD` directive.

Then, we can load the `.env` configuration into the Dockerfile, replacing the `.env` file's role. Finally, when running the container in docker-compose, we can override those ENV directives with the `env:` key, connecting the otherwise-isolated container to linked services.