### PR TITLE
[bug  ] ENV parsing would capture quotes as part of val, resulting in…

### DIFF
--- a/lib/dotenv_util.rb
+++ b/lib/dotenv_util.rb
@@ -2,6 +2,14 @@
 
 # Provides Generic support for manipulating Dotenv files
 class DotenvUtil
+  ENV_LINE_PATTERN = /^ # A line
+    (?<key>[A-Z_]+) # Beginning with al alphanumeric key
+    =               # Then an equals sign
+    (?<quot>"|')?   # Possibly a quote sign
+    (?<val>[^"']+)? # The value, anything other than quote signs
+    (\g<quot>)?     # If there was a quote sign, match its partner
+    $/x # End of line (x = allow free spacing)
+
   attr_reader :env_text, :env
   def initialize(env_file)
     @env_text = env_file
@@ -22,9 +30,9 @@ class DotenvUtil
 
   def parse_env_file
     env_text.split.each_with_object({}) do |line, hash|
-      match = line.match(/^([A-Z_]+)="?(.+)?"?$/)
+      match = line.match(ENV_LINE_PATTERN)
       next unless match
-      hash.store(*match.captures)
+      hash.store(match[:key], match[:val])
       hash
     end
   end

--- a/spec/lib/dotenv_util_spec.rb
+++ b/spec/lib/dotenv_util_spec.rb
@@ -13,13 +13,12 @@ RSpec.describe DotenvUtil do
   end
 
   describe "#generate_env" do
-    it "Replaces an env variable in the file with a given string" do
+    it "Replaces an env variable in the file with a given string, quoting if necessary" do
       util = DotenvUtil.new(env_text)
       util.set("FAVORITE_FOOD", "FILET MIGNON")
       new_env = util.generate_env
 
-      favorite_food = new_env.match(/^FAVORITE_FOOD="(?<env>.*)"$/)[:env]
-      expect(favorite_food).to eq "FILET MIGNON"
+      expect(new_env).to match /FAVORITE_FOOD="FILET MIGNON"\s/
     end
 
     it "Sets a new env variable which doesn't exist in the file" do
@@ -27,15 +26,13 @@ RSpec.describe DotenvUtil do
       util.set("BANANA", "YES")
       new_env = util.generate_env
 
-      banananess = new_env.match(/^BANANA="(?<env>.*)"$/)[:env]
-      expect(banananess).to eq "YES"
+      expect(new_env).to match /BANANA=YES/
     end
 
     it "Doesn't mess up by putting an extra quote around the val" do
       util = DotenvUtil.new(env_text)
       new_env = util.generate_env
-      color = new_env.match(/^FAVORITE_COLOR="(?<color>.*)"$/)[:color]
-      expect(color).to eq("RED")
+      expect(new_env).to match /FAVORITE_COLOR="RED"\s/
     end
 
     it "Has no problem when the has no values" do

--- a/spec/lib/dotenv_util_spec.rb
+++ b/spec/lib/dotenv_util_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe DotenvUtil do
       expect(banananess).to eq "YES"
     end
 
+    it "Doesn't mess up by putting an extra quote around the val" do
+      util = DotenvUtil.new(env_text)
+      new_env = util.generate_env
+      color = new_env.match(/^FAVORITE_COLOR="(?<color>.*)"$/)[:color]
+      expect(color).to eq("RED")
+    end
+
     it "Has no problem when the has no values" do
       empty_envs = <<-EOF
         NOTHING=

--- a/spec/lib/egg/configuration_spec.rb
+++ b/spec/lib/egg/configuration_spec.rb
@@ -17,9 +17,7 @@ RSpec.describe Egg::Configuration do
       env_util.set("DATABASE_URL", database_url)
       update_env_file = env_util.generate_env
 
-      written_db_url = update_env_file
-                       .match(/^DATABASE_URL="(?<url>.*)"$/)[:url]
-      expect(written_db_url).to eq(database_url)
+      expect(update_env_file).to match %r{DATABASE_URL=postgres://egg:postgreswins@db/egg_database}
     end
   end
 end


### PR DESCRIPTION
… bugged .env files

@hatchloyalty/platform 

So we'd get things like
```
TWILIO_AUTH_TOKEN="test_token"
TWILIO_PHONE_NUMBERS="123-456-7890""
SMS_CONFIRMATION_URL_ROOT="http://hatch.sms.test""
```
which ends up causing the 500 error Rod was encountering in https://github.com/hatchloyalty/core-service/pull/71