### PR TITLE
[fixup] Relax thor dependency for compatability with Napa

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    egg (0.5.0)
-      thor (~> 0.19.4)
+    egg (0.5.1)
+      thor (~> 0.19.0)
 
 GEM
   remote: https://rubygems.org/

--- a/egg.gemspec
+++ b/egg.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "thor", "~> 0.19.4"
+  spec.add_runtime_dependency "thor", "~> 0.19.0"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
@hatchloyalty/platform 
When trying to set up egg for email-service, I discovered that it wouldn't install the gem due to a dependency clash with napa's thor version. Egg doesn't need to ask for thor 0.19.4. 