### PR TITLE
Support before/after for run, env, add

### DIFF
--- a/lib/egg/dockerfile/base.rb
+++ b/lib/egg/dockerfile/base.rb
@@ -2,6 +2,13 @@ module Egg
   module Dockerfile
     # Provides shared behavior for dockerfile template classes.
     class Base
+      # Raise when before and after are both used at the same time.
+      class QuantumStateError < RuntimeError
+        def message
+          "Directives cannot happen both before and after a given directive"
+        end
+      end
+
       attr_reader :template
       attr_accessor :command
 
@@ -42,6 +49,7 @@ module Egg
       private
 
       def insert_with_before_after(directive, before: nil, after: nil)
+        raise(QuantumStateError) if before && after
         if before
           template.insert(find_directive_in_template(before), directive)
         elsif after

--- a/lib/egg/dockerfile/base.rb
+++ b/lib/egg/dockerfile/base.rb
@@ -43,23 +43,17 @@ module Egg
 
       def insert_with_before_after(directive, before: nil, after: nil)
         if before
-          template.insert(do_before(before), directive)
+          template.insert(find_directive_in_template(before), directive)
         elsif after
-          template.insert(do_after(after) + 1, directive)
+          template.insert(find_directive_in_template(after) + 1, directive)
         else
           template << directive
         end
       end
 
-      def do_before(before)
-        template.index(before) ||
-          template.index { |tc| tc[0] == before[0] } ||
-          -1
-      end
-
-      def do_after(after)
-        template.index(after) ||
-          template.index { |tc| tc[0] == after[0] } ||
+      def find_directive_in_template(directive)
+        template.index(directive) ||
+          template.index { |tc| tc[0] == directive[0] } ||
           -1
       end
 

--- a/spec/lib/dockerfile_spec.rb
+++ b/spec/lib/dockerfile_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe Egg::Dockerfile do
       df.run "echo before bundling", before: [:run, "bundle install"]
       expect(df.render).to match(/^RUN echo before bundling\nRUN bundle install$/)
     end
+
+    it "raises an exception if both before and after are specified" do
+      expect {
+        df.run "echo before bundling", before: [:run, "bundle install"], after: [:run, "bundle install"]
+      }.to raise_error(Egg::Dockerfile::Base::QuantumStateError)
+    end
   end
 
   describe "command" do

--- a/spec/lib/dockerfile_spec.rb
+++ b/spec/lib/dockerfile_spec.rb
@@ -2,6 +2,13 @@ require "spec_helper"
 require "egg/dockerfile"
 
 RSpec.describe Egg::Dockerfile do
+  let(:df) do
+    df = Egg::Dockerfile.use("Ruby")
+    df.command = "test"
+    df.ruby_version = "2.3.3"
+    df
+  end
+
   it "can be configured with a #use" do
     df = Egg::Dockerfile.use("NodeJS")
     expect(df).to be_an_instance_of(Egg::Dockerfile::NodeJS)
@@ -33,28 +40,31 @@ RSpec.describe Egg::Dockerfile do
 
   describe "command" do
     it "Appends the command at the end" do
-      df = Egg::Dockerfile.use("Ruby")
-      df.command = "test"
-      df.ruby_version = "2.3.3"
       expect(df.render).to match(/CMD test$/)
     end
   end
 
   describe "#env" do
     it "Appends a ENV directive" do
-      df = Egg::Dockerfile.use("Ruby")
-      df.command = "test"
-      df.ruby_version = "2.3.3"
       df.env(FOO: "ENV SET")
       expect(df.render).to match(/ENV FOO="ENV SET"/)
     end
 
     it "May append multiple vars" do
-      df = Egg::Dockerfile.use("Ruby")
-      df.command = "test"
-      df.ruby_version = "2.3.3"
       df.env(FOO: "ENV SET", bar: "SetAnother123")
       expect(df.render).to match(/ENV FOO="ENV SET" BAR="SetAnother123"/)
+    end
+  end
+
+  describe "#add" do
+    it "Appends an ADD directive" do
+      df.add "testfile", "testLocation"
+      expect(df.render).to match(/ADD testfile testLocation/)
+    end
+
+    it "Allows the ADD to be added after another directive" do
+      df.add("testfile", "testLocation", after: [:add, "Gemfile* $APP_HOME/"])
+      expect(df.render).to match(%r{ADD Gemfile\* \$APP_HOME/\nADD testfile testLocation})
     end
   end
 end


### PR DESCRIPTION
@hatchloyalty/platform 

I needed to insert the `messenger` folder before bundle install in core-service or it will fail to bundle install, since it's previously only adding the Gemfile and Gemfile.lock.

So I took a look at the code and decided to refactor a bit and add a generalized mechanism for before/after insertion.