### PR TITLE
[feat ] Support alternate run modes by dropping automatic up

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,18 @@
     <br>
 </h1>
 
-![CircleCI](https://circleci.com/gh/bellycard/egg.png?style=shield&circle-token=10677521a50bce69aca6ec419794d1c44d3cd12a) [![Gem Version](https://badge.fury.io/rb/egg.svg)](https://badge.fury.io/rb/egg)
+![CircleCI](https://circleci.com/gh/hatchloyalty/egg.png?style=shield&circle-token=10677521a50bce69aca6ec419794d1c44d3cd12a) [![Gem Version](https://badge.fury.io/rb/egg.svg)](https://badge.fury.io/rb/egg)
 
-> Egg helps prevent code fires! Also he makes it easy to run complex multi-service apps with Docker.
+> Egg helps prevent code fires! Also he makes it easy to run complex
+> multi-service apps with Docker.
 
 Maintainers:
 * [Carl Thuringer](https://github.com/carlthuringer)
 * [Jason Sisk](https://github.com/sisk)
 
-This gem is currently heavily focused on Ruby and Rails projects relevant within 
-the Hatch organization. The eventual goal is for this to become language and 
-framework agnostic, though the configuration language will be Ruby. 
+This gem is currently heavily focused on Ruby and Rails projects relevant within
+the Hatch organization. The eventual goal is for this to become language and
+framework agnostic, though the configuration language will be Ruby.
 
 ## Installation
 
@@ -36,20 +37,31 @@ Or install it yourself as:
 ## Usage
 * `init` - Initialize a repo for use with Egg. Creates the `egg_config.rb`
 * `readme` - Display the Usage readme
-* `setup` - Generates the docker files from the configuration, runs all setup hooks, then boots the application.
+* `setup` - Generates the docker files from the configuration, runs all setup hooks.
+* `docker-compose up` - Boot the application with docker-compose.
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. You can
+also run `bin/console` for an interactive prompt that will allow you to
+experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. To
+release a new version, update the version number in `version.rb`, and then run
+`bundle exec rake release`, which will create a git tag for the version, push
+git commits and tags, and push the `.gem` file to
+[rubygems.org](https://rubygems.org).
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/bellycard/egg. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at
+https://github.com/hatchloyalty/egg. This project is intended to be a safe,
+welcoming space for collaboration, and contributors are expected to adhere to
+the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 
 ## License
 
-The gem is available as open source under the terms of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+The gem is available as open source under the terms of the
+[Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 

--- a/lib/egg/cli.rb
+++ b/lib/egg/cli.rb
@@ -33,6 +33,7 @@ module Egg
     def setup
       config = Configuration.load "./egg_config.rb"
       config.run_setup
+      print "Use `docker-compose up` to start your application."
     end
 
     desc "build", "Just build the docker containers"

--- a/lib/egg/configuration.rb
+++ b/lib/egg/configuration.rb
@@ -35,7 +35,7 @@ module Egg
       self.ruby_version = "2.4"
       self.dotenv = DotenvUtil.new(File.read(".env.template"))
       instance_eval(&configuration_block)
-      self
+      self # rubocop:disable Lint/Void
     end
 
     def after_startup(&block)
@@ -69,7 +69,6 @@ module Egg
 
       docker_pull_build
       File.write(".env", dotenv.generate_env)
-      system("docker-compose up -d")
 
       run_after_startup
     end


### PR DESCRIPTION
@hatchloyalty/platform 

Working with egg a bit more, I find that I don't necessarily want it booting up after I run setup. I'd prefer to control startup/shutdown myself, possibly by running it non-daemonized in another window.