### PR TITLE
Dont write dockerfiles

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -7,11 +7,12 @@ Egg makes it easy to set up a cluster of applications for local development, usi
 ```bash
 egg setup
 ```
-Once finished, the services will be running.
+Once finished, you may start the service with `docker-compose up`
 
 ### Stopping, Starting, Updating
 
 Most docker compose commands can apply to a single service if you follow the command with the service name (app, db)
+You may find this tool more pleasant to use if you `alias dc="docker-compose"`
 
 ```bash
 // Pause processes
@@ -30,6 +31,8 @@ docker-compose up -d
 docker-compose ps
 // Kill and remove all containers.
 docker-compose down
+// Kill other docker processes running elsewhere
+docker ps -q | xargs docker kill
 ```
 
 ### Getting into it

--- a/lib/egg/configuration.rb
+++ b/lib/egg/configuration.rb
@@ -74,8 +74,6 @@ module Egg
     end
 
     def write_docker_files
-      File.write("Dockerfile", dockerfile.render) if dockerfile
-
       dockerignore = Templates[".dockerignore"].result(binding)
       File.write(".dockerignore", dockerignore)
 

--- a/lib/egg/dockerfile.rb
+++ b/lib/egg/dockerfile.rb
@@ -5,6 +5,7 @@ module Egg
     class MissingPropertyError < StandardError; end
 
     def self.use(klass)
+      print "Dockerfile.use is deprecated. Egg setup will no longer write your dockerfile, please craft it yourself."
       const_get("Egg::Dockerfile::#{klass}").new
     rescue NameError
       raise(NoDockerfileError, "No Dockerfile subclass for #{klass}.")


### PR DESCRIPTION
@hatchloyalty/platform 

In order to move towards better usability, I'm dropping some of the assumptions that egg was making about how you want to run the environment.

The first was dropping the automatic `docker-compose up` starting of the application stack after running setup. Next, we're dropping generation of `Dockerfile` on every build and setup, enabling customization of the dockerfile, encoding ENV vars into the image, and reducing complexity.

In doing this I'm trying to recognize Docker's tools for their strengths and focus Egg on Docker's weaknesses for our use case. At this time it still seems useful to write the docker-compose file with Egg, but advanced YAML techniques may yet make that redundant, further reducing the complexity of Egg.